### PR TITLE
add csrf protection by http header

### DIFF
--- a/src/Krtv/Bundle/CsrfValidatorBundle/Annotations/CsrfHeader.php
+++ b/src/Krtv/Bundle/CsrfValidatorBundle/Annotations/CsrfHeader.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Krtv\Bundle\CsrfValidatorBundle\Annotations;
+
+
+use Doctrine\Common\Annotations\Annotation;
+
+/**
+ * Csrf reader from HTTP Headers
+ *
+ * @Annotation
+ * @Target("METHOD")
+ *
+ * @package Krtv\Bundle\CsrfValidatorBundle\Annotations
+ */
+class CsrfHeader extends Annotation
+{
+    /**
+     * @var string Intention for CSRF token
+     */
+    public $intention;
+
+    /**
+     * @var string HTTP header to read CSRF token
+     */
+    public $httpHeader = 'X-CSRF-Token';
+}

--- a/src/Krtv/Bundle/CsrfValidatorBundle/ReaderManager/AbstractReaderManager.php
+++ b/src/Krtv/Bundle/CsrfValidatorBundle/ReaderManager/AbstractReaderManager.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Krtv\Bundle\CsrfValidatorBundle\ReaderManager;
+
+use Krtv\Bundle\CsrfValidatorBundle\Annotations\Csrf;
+use Doctrine\Common\Annotations\Reader;
+use Doctrine\Common\Annotations\Annotation;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Security\Csrf\CsrfToken;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+
+/**
+ * Implements basic methods for other reader managers
+ *
+ * @package Krtv\Bundle\CsrfValidatorBundle\ReaderManager
+ */
+abstract class AbstractReaderManager implements ReaderManagerInterface
+{
+
+    /**
+     * @var RequestStack
+     */
+    protected $requestStack;
+
+    /**
+     * @var CsrfTokenManagerInterface
+     */
+    protected $csrfManager;
+
+    /**
+     * @var Reader
+     */
+    protected $reader;
+
+    /**
+     * @var string Class to be supported by reader
+     */
+    protected $annotationClass;
+
+    /**
+     * @param RequestStack              $requestStack
+     * @param Reader                    $reader
+     * @param CsrfTokenManagerInterface $csrfManager
+     */
+    public function __construct(RequestStack $requestStack, CsrfTokenManagerInterface $csrfManager, Reader $reader)
+    {
+        $this->requestStack = $requestStack;
+        $this->csrfManager =  $csrfManager;
+        $this->reader =       $reader;
+    }
+
+    /**
+     * @param \ReflectionMethod $action
+     * @return bool|Annotation
+     */
+    public function supports(\ReflectionMethod $action)
+    {
+        $annotation = $this->reader->getMethodAnnotation($action, $this->annotationClass);
+        if ($annotation !== null) {
+            return $annotation;
+        }
+
+        return false;
+    }
+
+    /**
+     * Validates CSRF token from controller annotation.
+     *
+     * @param Annotation $annotation
+     *
+     * @return bool
+     */
+    abstract public function validate(Annotation $annotation);
+}

--- a/src/Krtv/Bundle/CsrfValidatorBundle/ReaderManager/HttpHeaderReaderManager.php
+++ b/src/Krtv/Bundle/CsrfValidatorBundle/ReaderManager/HttpHeaderReaderManager.php
@@ -2,34 +2,32 @@
 
 namespace Krtv\Bundle\CsrfValidatorBundle\ReaderManager;
 
-use Krtv\Bundle\CsrfValidatorBundle\Annotations\Csrf;
-
 use Doctrine\Common\Annotations\Annotation;
+use Krtv\Bundle\CsrfValidatorBundle\Annotations\CsrfHeader;
 use Symfony\Component\Security\Csrf\CsrfToken;
 
 /**
- * Class ReaderManager
- *
- * Read CSRF token from request params.
+ * Read CSRF token from HTTP header
  *
  * @package Krtv\Bundle\CsrfValidatorBundle\ReaderManager
  */
-class ReaderManager extends AbstractReaderManager
+class HttpHeaderReaderManager extends AbstractReaderManager
 {
     /**
      * @var string Class to be supported by reader
      */
-    protected $annotationClass = Csrf::class;
+    protected $annotationClass = CsrfHeader::class;
 
     /**
      * @inheritdoc
      */
     public function validate(Annotation $annotation)
     {
-        $token = $this->requestStack->getMasterRequest()->get($annotation->param);
+        /** @var CsrfHeader $annotation */
+        $token = $this->requestStack->getMasterRequest()->headers->get($annotation->httpHeader);
 
         return $this->csrfManager->isTokenValid(
             new CsrfToken($annotation->intention, $token)
         );
     }
-} 
+}


### PR DESCRIPTION
1. Add CSRF protection by HTTP header
2. Add new abstraction layer for ReaderManager

Code to add protection by HTTP header:

```php
use Krtv\Bundle\CsrfValidatorBundle\Annotations\CsrfHeader;

class MyController
{
    /**
     * @CsrfHeader(intention="my_intention", httpHeader="X-My-CSRF-Token")
     */
    public function testAction()
    {
    }
}
```

```yaml
parameters:
    krtv.csrf_validator.reader_manager.class: Krtv\Bundle\CsrfValidatorBundle\ReaderManager\HttpHeaderReaderManager
```